### PR TITLE
Add --logdate option to include date in logging

### DIFF
--- a/cado-nfs-client.py
+++ b/cado-nfs-client.py
@@ -1490,6 +1490,8 @@ if __name__ == '__main__':
         parser.add_option("--override", nargs=2, action='append',
                           metavar=('REGEXP', 'VALUE'),
                           help="Modify command-line arguments which match ^-{1,2}REGEXP$ to take the given VALUE. Note that REGEXP cannot start with a dash")
+        parser.add_option("--logdate", default=True, action='store_true',
+                          help="Include ISO8601 format date in logging")
         # Parse command line
         (options, args) = parser.parse_args()
 
@@ -1568,7 +1570,12 @@ if __name__ == '__main__':
         logfilename = "%s/%s.log" % (SETTINGS["WORKDIR"], SETTINGS["CLIENTID"])
         SETTINGS["LOGFILE"] = logfilename
     logfile = None if logfilename is None else open(logfilename, "a")
-    logging.basicConfig(level=loglevel)
+    if options.logdate:
+        logging.basicConfig(
+            format='%(asctime)s - %(levelname)s:%(name)s:%(message)s',
+            level=loglevel)
+    else:
+        logging.basicConfig(level=loglevel)
     if logfile:
         logging.getLogger().addHandler(logging.StreamHandler(logfile))
     logging.info("Starting client %s", SETTINGS["CLIENTID"])


### PR DESCRIPTION
```
seven@seven:~/Projects/cado-nfs$ python ./cado-nfs-client.py --nologdate --bindir=build/$(hostname) --server=<SERVER> 
INFO:root:Starting client seven.107d4036
INFO:root:Python version is 3.6.8
INFO:root:Downloading <SERVER>/cgi-bin/getwu?clientid=seven.107d4036 to download/WU.seven.107d4036 (cafile = None)
INFO:root:download/2330L.c207.roots1.gz already exists, not downloading
INFO:root:download/2330L.c207.poly already exists, not downloading
INFO:root:Result file seven.107d4036.work/2330L.c207.173652500-173655000.gz does not exist
INFO:root:Running 'build/seven/sieve/las' -I 16 -poly 'download/2330L.c207.poly' -q0 173652500 -q1 173655000 -lim0 268000000 -lim1 535000000 -lpb0 34 -lpb1 35 -mfb0 66 -mfb1 99 -ncurves0 27 -ncurves1 17 -fb1 'download/2330L.c207.roots1.gz' -out 'seven.107d4036.work/2330L.c207.173652500-173655000.gz' -t 16 -stats-stderr

seven@seven:~/Projects/cado-nfs$ python ./cado-nfs-client.py --override t 16 --bindir=build/$(hostname) --server=<SERVER>
2019-07-19 01:30:32,268 - INFO:root:Starting client seven.d6c1f5fe
2019-07-19 01:30:32,268 - INFO:root:Python version is 3.6.8
2019-07-19 01:30:32,268 - INFO:root:Downloading <SERVER>/cgi-bin/getwu?clientid=seven.d6c1f5fe to download/WU.seven.d6c1f5fe (cafile = None)
2019-07-19 01:30:32,349 - INFO:root:download/2330L.c207.roots1.gz already exists, not downloading
2019-07-19 01:30:32,752 - INFO:root:download/2330L.c207.poly already exists, not downloading
2019-07-19 01:30:32,752 - INFO:root:Result file seven.d6c1f5fe.work/2330L.c207.173650000-173652500.gz does not exist
```